### PR TITLE
#8 Angular now gets the desks from the datastore on GCP - we can lock…

### DIFF
--- a/src/app/pages/choose-desk/choose-desk.component.html
+++ b/src/app/pages/choose-desk/choose-desk.component.html
@@ -14,7 +14,14 @@
 </div>
 
 <div id="desks">
-  <div *ngFor="let name of names">
-    <div (click)="selectDesk(name)" class="desk">{{name}}</div>
+  <div *ngFor="let desk of desks">
+    <div (click)="selectDesk(desk.id)" class="desk">
+      <div *ngIf="desk.booked === false; else strikethrough">
+          {{desk.name}}
+      </div>
+      <ng-template #strikethrough>
+          <s>{{desk.name}}</s>   
+      </ng-template>
+    </div>
   </div>
 </div>

--- a/src/app/pages/choose-desk/choose-desk.component.ts
+++ b/src/app/pages/choose-desk/choose-desk.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit, NgModule } from '@angular/core';
 import { Validators, FormsModule } from '@angular/forms';
-
-import { AuthService } from './../../auth/auth.service';
+import { DatastoreService } from 'src/app/services/datastore.service';
 
 
 @Component({
@@ -15,13 +14,28 @@ import { AuthService } from './../../auth/auth.service';
   ]
 })
 export class ChooseDeskComponent implements OnInit {
-  names;
+  desks: Array<any>;
   constructor(
     // public authService: AuthService
+    private datastoreService: DatastoreService
   ) { }
 
   ngOnInit() {
-    this.names = ["jovial_goldberg","big_volhard","backstabbing_elion","sick_poincare","mad_carson","furious_payne","cranky_lumiere","hopeful_allen","gloomy_volhard","thirsty_morse"];
+  
+    this.datastoreService.getDesks()
+    .subscribe(
+      (desks: any) =>{
+        console.log("res: ", desks.items);
+        this.desks = desks.items;
+        
+      }, 
+      error =>{
+        console.log("error message:", error);
+      }
+    );
+
+
+
   }
 
   selectDesk(name) {

--- a/src/app/services/datastore.service.spec.ts
+++ b/src/app/services/datastore.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { DatastoreService } from './datastore.service';
+
+describe('DatastoreService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [DatastoreService]
+    });
+  });
+
+  it('should be created', inject([DatastoreService], (service: DatastoreService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/app/services/datastore.service.ts
+++ b/src/app/services/datastore.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { AuthService } from '../auth/auth.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DatastoreService {
+
+  DESKS_API_URL: string = 'http://localhost:8080/api'
+  // DESKS_API_URL: string = 'https://no8-iot-desk-occupancy.appspot.com/api'
+  message: string;
+
+  constructor(
+    private http: HttpClient,
+    public auth: AuthService
+    ) { }
+
+  getDesks() {    
+    return this.http.get(this.DESKS_API_URL + '/desks');
+  }
+}


### PR DESCRIPTION
… down the /api endpoint in a similar fashion to the /email endpoint. Woohoo! Desks that are booked are now crossed out